### PR TITLE
Add support EN DASH character for Shift_JIS encodings

### DIFF
--- a/lib/wavedash.rb
+++ b/lib/wavedash.rb
@@ -34,6 +34,7 @@ module Wavedash
       "\u{FF5E}" => "\u{301C}", # 'FULLWIDTH TILDE' => 'WAVE DASH'
       "\u{FF0D}" => "\u{2212}", # 'FULLWIDTH HYPHEN-MINUS' => 'MINUS SIGN'
       "\u{2225}" => "\u{2016}", # 'PARALLEL TO' => 'DOUBLE VERTICAL LINE'
+      "\u{2013}" => "\u{2014}", # 'EN DASH' => 'EM DASH'
       "\u{FFE0}" => "\u{00A2}", # 'FULLWIDTH CENT SIGN' => 'CENT SIGN'
       "\u{FFE1}" => "\u{00A3}", # 'FULLWIDTH POUND SIGN' => 'POUND SIGN'
       "\u{FFE2}" => "\u{00AC}", # 'FULLWIDTH NOT SIGN' => 'NOT SIGN'

--- a/spec/encoding/shift_jis_spec.rb
+++ b/spec/encoding/shift_jis_spec.rb
@@ -55,6 +55,14 @@ describe 'destination encoding is shift_jis' do
       it_behaves_like 'a unencodable string before-after'
       it_behaves_like 'a expected normalization'
     end
+
+    context 'includes EN DASH(U+2013)' do
+      let(:str) { "–" }
+      let(:normalized_str) { "—" }
+
+      it_behaves_like 'a unencodable string before-after'
+      it_behaves_like 'a expected normalization'
+    end
   end
 
   describe '#invalid?' do
@@ -84,6 +92,10 @@ describe 'destination encoding is shift_jis' do
 
     it 'returns true when include FULLWIDTH NOT SIGN(0+FFE2)' do
       expect(Wavedash.invalid?("￢")).to be_truthy
+    end
+
+    it 'returns true when include EN DASH(0+2013)' do
+      expect(Wavedash.invalid?("–")).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Hi, I added code mapping for EN DASH(U+2013).
I think that there is no need to divide En dash and Em dash in the case, such as Shift-JIS is used.