### PR TITLE
Unpin bundler and rake versions

### DIFF
--- a/wavedash.gemspec
+++ b/wavedash.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
In Ruby 3.x, the version of Bundler is 2.x. There is no version dependent code. So we are going to stop specifying the version.
